### PR TITLE
Add optional GitHub organisation authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,14 @@
----
+sudo: required
 language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - pip install ansible docker 'molecule<1.22'
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ services:
 
 install:
   - pip install ansible docker 'molecule<1.22'
+  - mkdir roles
+  - ln -s ../ roles/ansible-role-idr-jupyter
 
 script:
-  - molecule test
+  - ansible-lint -v .
+  - ansible-galaxy install -p roles -r tests/requirements.yml
+  - ANSIBLE_ROLES_PATH=.. ansible-playbook -i localhost, playbook.yml --syntax-check
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -8,9 +8,25 @@ Work in progress.
 This was moved from an IDR playbook so all vars still reference the IDR.
 
 
-
 Role Variables
 --------------
+
+See `defaults/main.yml` for defaults.
+All variables are optional.
+Some of the most useful ones are:
+- `idr_jupyter_hub_image`: The Jupyterhub docker image
+- `idr_jupyter_notebook_image`: The Jupyter notebook docker image
+- `idr_jupyter_notebook_volumes`: JSON mapping of host volumes to internal notebook docker paths
+- `idr_jupyter_users`: List of users that can use Jupyterhub
+- `idr_jupyter_admins`: List of users with Jupyterhub admin privileges
+- `idr_jupyter_urlbase`: The base for URLs created by Jupyterhub
+
+
+Example Playbook
+----------------
+
+See [playbook.yml](playbook.yml).
+Once deployed you should be able to login to JupyterHub at http://localhost:8000, username: `user`, password `ome`.
 
 
 Author Information

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,8 @@ idr_jupyter_users:
 idr_jupyter_admins:
 - root
 
+idr_jupyter_github_orgs: []
+
 idr_jupyter_urlbase: "http://localhost"
 idr_jupyter_prefix: "/jupyter"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+# Handlers for idr-jupyter
+
+- name: reload systemd
+  become: yes
+  command: systemctl daemon-reload
+
+- name: restart jupyterhub
+  become: yes
+  service:
+    name: docker-jupyterhub.service
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,11 +3,15 @@ galaxy_info:
   description: Setup a JupyterHub server in Docker
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.2
   platforms:
   - name: EL
     versions:
     - 7
   galaxy_tags: []
 
-dependencies: []
+dependencies:
+- name: openmicroscopy.docker
+  src: openmicroscopy.docker
+- name: openmicroscopy.docker-tools
+  src: openmicroscopy.docker-tools

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,37 @@
+---
+dependency:
+  name: galaxy
+  requirements_file: tests/requirements.yml
+
+# Default driver
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: idr-jupyter
+
+docker:
+  containers:
+  - name: idr-jupyter
+    image: manics/centos-systemd-ip-docker
+    image_version: latest
+    privileged: True
+
+ansible:
+  host_vars:
+    idr-jupyter:
+      # Use a smaller notebook image for testing
+      idr_jupyter_notebook_image: "jupyter/minimal-notebook:latest"
+
+verifier:
+  name: testinfra

--- a/molecule.yml
+++ b/molecule.yml
@@ -5,7 +5,7 @@ dependency:
 
 # Default driver
 driver:
-  name: docker
+  name: vagrant
 
 vagrant:
   platforms:
@@ -19,19 +19,6 @@ vagrant:
         cpus: 1
   instances:
     - name: idr-jupyter
-
-docker:
-  containers:
-  - name: idr-jupyter-docker
-    image: manics/centos-systemd-ip-docker
-    image_version: latest
-    privileged: True
-
-ansible:
-  host_vars:
-    idr-jupyter-docker:
-      # Use a dummy image for testing (otherwise Travis runs out of space)
-      idr_jupyter_notebook_image: busybox
 
 verifier:
   name: testinfra

--- a/molecule.yml
+++ b/molecule.yml
@@ -22,16 +22,16 @@ vagrant:
 
 docker:
   containers:
-  - name: idr-jupyter
+  - name: idr-jupyter-docker
     image: manics/centos-systemd-ip-docker
     image_version: latest
     privileged: True
 
 ansible:
   host_vars:
-    idr-jupyter:
-      # Use a smaller notebook image for testing
-      idr_jupyter_notebook_image: "jupyter/minimal-notebook:latest"
+    idr-jupyter-docker:
+      # Use a dummy image for testing (otherwise Travis runs out of space)
+      idr_jupyter_notebook_image: busybox
 
 verifier:
   name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,21 @@
+---
+- hosts: all
+  roles:
+  - role: ansible-role-idr-jupyter
+    idr_jupyter_ip: "{{ ansible_eth0.ipv4.address }}"
+    # `user` must exist in the jupyterhub Docker container
+    idr_jupyter_users: [user]
+    idr_jupyter_admins: [user]
+    idr_jupyter_notebook_volumes: "{ '/notebooks/{username}': '/notebooks' }"
+    idr_jupyter_hub_extra_docker_args: "-e USER_PASSWORD=ome"
+
+  tasks:
+  - name: Create notebook directory for user
+    become: yes
+    file:
+      path: "/notebooks/user"
+      owner: 1000
+      state: directory
+
+  # Setup a port-forward to 8000 and you should be able to login as
+  # user:user password:ome

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -6,19 +6,9 @@
   template:
     src: jupyterhub-docker.j2
     dest: /etc/systemd/system/docker-jupyterhub.service
-  register: systemdjupyter
-
-- name: jupyterhub | reload systemd
-  become: yes
-  command: systemctl daemon-reload
-  when: systemdjupyter.changed
-
-- name: jupyterhub | restart
-  become: yes
-  service:
-    name: docker-jupyterhub.service
-    state: restarted
-  when: jupyterconfig.changed
+  notify:
+  - reload systemd
+  - restart jupyterhub
 
 - name: jupyterhub | enable jupyterhub
   become: yes

--- a/tasks/dockerswarm.yml
+++ b/tasks/dockerswarm.yml
@@ -23,12 +23,9 @@
   template:
     src: jupyterhub-docker-swarm.j2
     dest: /etc/systemd/system/docker-jupyterhub.service
-  register: systemdjupyter
-
-- name: jupyterhub | reload systemd
-  become: yes
-  command: systemctl daemon-reload
-  when: systemdjupyter.changed
+  notify:
+  - reload systemd
+  - restart jupyterhub
 
 # Docker swarm may have started the service without telling systemd
 # so only restart if the config has changed or the service isn't
@@ -40,11 +37,11 @@
   register: docker_jupyter_service
   changed_when: "docker_jupyter_service.rc != 0"
   failed_when: "docker_jupyter_service.rc > 1"
+  notify:
+  - restart jupyterhub
 
-- name: jupyterhub | restart swarm
+- name: jupyterhub | ensure systemd swarm service disabled
   become: yes
   service:
     enabled: "no"
     name: docker-jupyterhub.service
-    state: restarted
-  when: (jupyterconfig.changed or docker_jupyter_service.changed)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,23 +33,6 @@
   - "{{ idr_jupyter_hub_image }}"
   - "{{ idr_jupyter_notebook_image }}"
 
-# TODO: The above `docker_image` only pulls latest
-# Should be fixed in Ansible 2.2
-# https://github.com/ansible/ansible/pull/16680
-# idr_jupyter_hub_image is automatically pulled since the systemd service
-# runs docker, but docker-py won't pull idr_jupyter_notebook_image
-- name: jupyterhub | check if notebook image present (ansible 2.1 bug)
-  become: yes
-  command: docker images -q "{{ idr_jupyter_notebook_image }}"
-  register: docker_image_jhnote
-  always_run: yes
-  changed_when: "{{ docker_image_jhnote.stdout | length }} < 1"
-
-- name: jupyterhub | pull notebook image (ansible 2.1 bug)
-  become: yes
-  command: docker pull "{{ idr_jupyter_notebook_image }}"
-  when: docker_image_jhnote.changed
-
 - include: docker.yml
   when: not idr_jupyter_docker_swarm
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,8 @@
     src: jupyterhub_config-py.j2
     dest: /srv/jupyterhub/jupyterhub_config.py
   register: jupyterconfig
+  notify:
+  - restart jupyterhub
 
 - name: jupyterhub | pull images
   become: yes

--- a/templates/jupyterhub_config-py.j2
+++ b/templates/jupyterhub_config-py.j2
@@ -73,10 +73,11 @@ c.Authenticator.admin_users = {{ idr_jupyter_admins | to_json }}
 {% if idr_jupyter_authenticator == 'system' %}
 # Use default authenticator
 {% elif idr_jupyter_authenticator == 'github' %}
-c.JupyterHub.authenticator_class = "oauthenticator.GitHubOAuthenticator"
+c.JupyterHub.authenticator_class = "oauthenticator.GitHubOrgOAuthenticator"
 c.GitHubOAuthenticator.oauth_callback_url = "{{ idr_jupyter_urlbase }}{{ idr_jupyter_prefix }}/hub/oauth_callback"
 c.GitHubOAuthenticator.client_id = "{{ idr_jupyter_github_id }}"
 c.GitHubOAuthenticator.client_secret = "{{ idr_jupyter_github_secret }}"
+c.GitHubOrgOAuthenticator.organisation_whitelist = "{{ idr_jupyter_github_org }}"
 {% else %}
 c.JupyterHub.authenticator_class = "{{ idr_jupyter_authenticator }}"
 {% endif %}

--- a/templates/jupyterhub_config-py.j2
+++ b/templates/jupyterhub_config-py.j2
@@ -77,7 +77,7 @@ c.JupyterHub.authenticator_class = "oauthenticator.GitHubOrgOAuthenticator"
 c.GitHubOAuthenticator.oauth_callback_url = "{{ idr_jupyter_urlbase }}{{ idr_jupyter_prefix }}/hub/oauth_callback"
 c.GitHubOAuthenticator.client_id = "{{ idr_jupyter_github_id }}"
 c.GitHubOAuthenticator.client_secret = "{{ idr_jupyter_github_secret }}"
-c.GitHubOrgOAuthenticator.organisation_whitelist = "{{ idr_jupyter_github_org }}"
+c.GitHubOrgOAuthenticator.github_organization_whitelist = "{{ idr_jupyter_github_orgs | to_json }}"
 {% else %}
 c.JupyterHub.authenticator_class = "{{ idr_jupyter_authenticator }}"
 {% endif %}

--- a/templates/jupyterhub_config-py.j2
+++ b/templates/jupyterhub_config-py.j2
@@ -73,11 +73,14 @@ c.Authenticator.admin_users = {{ idr_jupyter_admins | to_json }}
 {% if idr_jupyter_authenticator == 'system' %}
 # Use default authenticator
 {% elif idr_jupyter_authenticator == 'github' %}
+# TODO: Switch back to GitHubOAuthenticator
 c.JupyterHub.authenticator_class = "oauthenticator.GitHubOrgOAuthenticator"
 c.GitHubOAuthenticator.oauth_callback_url = "{{ idr_jupyter_urlbase }}{{ idr_jupyter_prefix }}/hub/oauth_callback"
 c.GitHubOAuthenticator.client_id = "{{ idr_jupyter_github_id }}"
 c.GitHubOAuthenticator.client_secret = "{{ idr_jupyter_github_secret }}"
-c.GitHubOrgOAuthenticator.github_organization_whitelist = "{{ idr_jupyter_github_orgs | to_json }}"
+# https://github.com/jupyterhub/oauthenticator/pull/58 is ready
+#c.GitHubOAuthenticator.github_organization_whitelist = {{ idr_jupyter_github_orgs | to_json }}
+c.GitHubOrgOAuthenticator.github_organization_whitelist = {{ idr_jupyter_github_orgs | to_json }}
 {% else %}
 c.JupyterHub.authenticator_class = "{{ idr_jupyter_authenticator }}"
 {% endif %}

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,2 @@
+- src: openmicroscopy.docker
+- src: openmicroscopy.docker-tools

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-  - role: ansible-role-idr-jupyter

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,24 @@
+import testinfra.utils.ansible_runner
+import pytest
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_services_running_and_enabled(Service):
+    assert Service('docker-jupyterhub').is_running
+    assert Service('docker-jupyterhub').is_enabled
+
+
+@pytest.mark.parametrize("password,status", [
+    ("ome", True),
+    ("incorrect", False),
+])
+def test_login(Command, password, status):
+    out = Command.check_output(
+        'curl -L --data %s %s',
+        'username=user&password=%s&submit=Sign+In' % password,
+        'http://localhost:8000/jupyter/hub/login?next=')
+    assert ('login_error' not in out) == status
+
+# TODO: check notebook container runs after login


### PR DESCRIPTION
This allows users authenticated with GitHub OAuth access if they are a member of a specified GitHub organisation.

WARNING: The molecule test is only a partial test of the role (it doesn't check that a notebook is running), and requires the vagrant driver, so can't be tested in travis.