### PR TITLE
Optionally attempt to dynamically look up callback baseurl (IDR-0.4.0)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,10 @@ idr_jupyter_admins:
 
 idr_jupyter_github_orgs: []
 
+idr_jupyter_github_auth_table: {}
+# Example:
+# { 1.2.3.4: [testid, testsecret, http://example.org] }
+
 idr_jupyter_urlbase: "http://localhost"
 idr_jupyter_prefix: "/jupyter"
 

--- a/templates/jupyterhub_config-py.j2
+++ b/templates/jupyterhub_config-py.j2
@@ -73,14 +73,26 @@ c.Authenticator.admin_users = {{ idr_jupyter_admins | to_json }}
 {% if idr_jupyter_authenticator == 'system' %}
 # Use default authenticator
 {% elif idr_jupyter_authenticator == 'github' %}
-# TODO: Switch back to GitHubOAuthenticator
-c.JupyterHub.authenticator_class = "oauthenticator.GitHubOrgOAuthenticator"
-c.GitHubOAuthenticator.oauth_callback_url = "{{ idr_jupyter_urlbase }}{{ idr_jupyter_prefix }}/hub/oauth_callback"
-c.GitHubOAuthenticator.client_id = "{{ idr_jupyter_github_id }}"
-c.GitHubOAuthenticator.client_secret = "{{ idr_jupyter_github_secret }}"
+# TODO: Switch back to GitHubOAuthenticator when
 # https://github.com/jupyterhub/oauthenticator/pull/58 is ready
-#c.GitHubOAuthenticator.github_organization_whitelist = {{ idr_jupyter_github_orgs | to_json }}
+c.JupyterHub.authenticator_class = "oauthenticator.GitHubOrgOAuthenticator"
 c.GitHubOrgOAuthenticator.github_organization_whitelist = {{ idr_jupyter_github_orgs | to_json }}
+#c.GitHubOAuthenticator.github_organization_whitelist = {{ idr_jupyter_github_orgs | to_json }}
+
+gh_auth_params = ("{{ idr_jupyter_github_id }}", "{{ idr_jupyter_github_secret }}", "{{ idr_jupyter_urlbase }}")
+gh_auth_table = {{ idr_jupyter_github_auth_table | to_json }}
+try:
+    if gh_auth_table:
+        import requests
+        ip = requests.get('https://api.ipify.org').text
+        gh_auth_params = gh_auth_table[ip]
+except Exception as e:
+    import sys
+    sys.stderr.write('ERROR: %r\n' % e)
+
+c.GitHubOAuthenticator.client_id = gh_auth_params[0]
+c.GitHubOAuthenticator.client_secret = gh_auth_params[1]
+c.GitHubOAuthenticator.oauth_callback_url = gh_auth_params[2] + "{{ idr_jupyter_prefix }}/hub/oauth_callback"
 {% else %}
 c.JupyterHub.authenticator_class = "{{ idr_jupyter_authenticator }}"
 {% endif %}


### PR DESCRIPTION
This is an attempt at making testing easier by providing an optional additional table of IPs<->github-credentials and attempting to use the correct set based on the auto-detected external IP of the system. The default (which is configured in the same way as at present) will always be used in the event of error or an unknown IP.