### PR TITLE
Fix failing role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,16 @@
     state: directory
     mode: 0755
 
+- name: jupyterhub | setup python3 virtualenv
+  become: true
+  pip:
+    name:
+      # Required for cryptography 3.4
+      - pip>=21.0.1
+    state: present
+    virtualenv: "{{ idr_jupyter_basedir }}/venv"
+    virtualenv_command: /usr/bin/python3 -mvenv
+
 - name: jupyterhub | install python3 packages in virtualenv
   become: true
   pip:
@@ -58,7 +68,6 @@
       - oauthenticator==0.11.0
     state: present
     virtualenv: "{{ idr_jupyter_basedir }}/venv"
-    virtualenv_command: /usr/bin/python3 -mvenv
   notify:
     - restart jupyterhub
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,8 @@
   become: true
   pip:
     name:
+      # Required for cryptography 3.4
+      - pip>=21.0.1
       - jupyterhub==1.1.0
       # Remember to update cull idle script below when upgrading jupyterhub
       - dockerspawner==0.11.1


### PR DESCRIPTION
Following the `cryptography 3.4` release, a more recent version of `pip` is required to  install the dependency of this role.

Proposing this as a quick fix of the role. Since we are not using it anywhere, we might be moving towards deprecating it.
